### PR TITLE
CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,12 @@ env:
     - PYTHON_VERSION: 2.7
     - PYTHON_VERSION: 3.4
     
-matrix:
-  allow_failures:
-    - env: PYTHON_VERSION=3.4
-
 install:
-- wget https://raw.githubusercontent.com/menpo/condaci/v0.3.0/condaci.py -O condaci.py
-- python condaci.py setup $PYTHON_VERSION --channel $BINSTAR_USER
-- export PATH=$HOME/miniconda/bin:$PATH
+- wget https://raw.githubusercontent.com/menpo/condaci/v0.4.3/condaci.py -O condaci.py
+- python condaci.py setup
 
 script:
-- python condaci.py auto ./conda --binstarchannel main --binstaruser $BINSTAR_USER --binstarkey $BINSTAR_KEY
+- ~/miniconda/bin/python condaci.py build ./conda
 
 notifications:
   slack:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,22 +11,17 @@ environment:
       
 matrix:
   fast_finish: true
-  allow_failures:
-    - platform: x86
-      PYTHON_VERSION: 3.4
-    - platform: x64
-      PYTHON_VERSION: 3.4
 
 platform:
 - x86
 - x64
 
 init:
-- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/v0.3.0/condaci.py' C:\\condaci.py; echo "Done"
-- cmd: python C:\\condaci.py setup %PYTHON_VERSION% --channel %BINSTAR_USER%
+- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/v0.4.3/condaci.py' C:\\condaci.py; echo "Done"
+- cmd: python C:\\condaci.py setup
 
 install:
-- cmd: C:\\Miniconda\\python C:\\condaci.py auto ./conda --binstarchannel main --binstaruser %BINSTAR_USER% --binstarkey %BINSTAR_KEY%
+- cmd: C:\\Miniconda\\python C:\\condaci.py build ./conda
 
 notifications:
   - provider: Slack

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -5,7 +5,8 @@ cd build
 
 rem Need to handle Python 3.x case at some point (Visual Studio 2010)
 if %ARCH%==32 (
-    set CMAKE_CONFIG="Release|Win32"
+  set CMAKE_CONFIG="Release"
+
   if %PY_VER% LSS 3 (
 	set GENERATOR="Visual Studio 9 2008"
   ) else (
@@ -13,7 +14,8 @@ if %ARCH%==32 (
   )
 )
 if %ARCH%==64 (
-    set CMAKE_CONFIG="Release|x64"
+  set CMAKE_CONFIG="Release"
+
   if %PY_VER% LSS 3 (
 	set GENERATOR="Visual Studio 9 2008 Win64"
   ) else (
@@ -21,28 +23,38 @@ if %ARCH%==64 (
   )
 )
 
+set CMAKE_COMMAND="%LIBRARY_BIN%\bin\cmake.exe"
+set CMAKE_ROOT="%LIBRARY_BIN%\share\cmake-3.3"
+
 rem The Python lib has no period in the
 rem version string, so we remove it here.
 set PY_VER_NO_DOT=%PY_VER:.=%
 
-cmake ..\tools\python -LAH -G%GENERATOR% ^
+%CMAKE_COMMAND% ..\tools\python -LAH -G%GENERATOR% ^
 -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
 -DBUILD_SHARED_LIBS=1 ^
 -DBoost_USE_STATIC_LIBS=0 ^
 -DBoost_USE_STATIC_RUNTIME=0 ^
 -DBOOST_INCLUDEDIR="%LIBRARY_INC%" ^
 -DBOOST_LIBRARYDIR="%LIBRARY_LIB%" ^
+-DPYTHON3=%PY3K% ^
 -DPYTHON_LIBRARY="%PREFIX%\libs\python%PY_VER_NO_DOT%.lib" ^
 -DPYTHON_INCLUDE_DIR="%PREFIX%\include" ^
+-DDLIB_LINK_WITH_SQLITE3=0 ^
+-DDLIB_LINK_WITH_LIBPNG=1 ^
+-DPNG_INCLUDE_DIR="%LIBRARY_INC%" ^
+-DPNG_PNG_INCLUDE_DIR="%LIBRARY_INC%" ^
+-DDLIB_LINK_WITH_LIBJPEG=1 ^
 -DDLIB_NO_GUI_SUPPORT=1 ^
 -DDLIB_USE_BLAS=0 ^
 -DDLIB_USE_LAPACK=0
 
-cmake --build . --config %CMAKE_CONFIG% --target ALL_BUILD
-cmake --build . --config %CMAKE_CONFIG% --target INSTALL
+%CMAKE_COMMAND% --build . --config %CMAKE_CONFIG% --target ALL_BUILD
+%CMAKE_COMMAND% --build . --config %CMAKE_CONFIG% --target INSTALL
 
 rem Copy the dlib libraries and the dlls it depends upon
 rem Unfortunately, they have to be put in the root.
+cp "%LIBRARY_BIN%\libpng16.dll" "%SP_DIR%\libpng16.dll"
 move "..\python_examples\*.dll" "%SP_DIR%"
 move "..\python_examples\dlib.lib" "%SP_DIR%"
 move "..\python_examples\dlib.pyd" "%SP_DIR%"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -7,16 +7,25 @@ source:
   url: http://sourceforge.net/projects/dclib/files/dlib/v18.16/dlib-18.16.tar.bz2/download
   sha1: 6b4944ea3638e896016f3cbb286da9c1faa4d588
 
+build:
+  number: 1
+
 requirements:
   build:
    - python
-   - cmake  # [win]
+   - cmake 3.3.0  # [not osx]
    - boost 1.56.0
+   # On OSX Davis has forced building the static version
+   # On Windows there is a conflict between this jpeg and windows.h
+   - jpeg 8d  # [linux]
+   - libpng 1.6.17
    - sqlite 3.8.4.1  # [unix]
 
   run:
    - python
    - boost 1.56.0
+   - jpeg 8d  # [linux]
+   - libpng 1.6.17
    - sqlite 3.8.4.1  # [unix]
 
 test:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,7 +8,7 @@ source:
   sha1: 6b4944ea3638e896016f3cbb286da9c1faa4d588
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Enable continuous integration building for dlib. This involved a lot of trail and error to see what was wrong on Travis, Jenkins and Appveyor. In the end:
- Use CMake 3.3.0 rather than the older CMake versions shipped with the distros
- Update condaci to properly set up VS2008
- Enable png and jpeg linking
- Limit number of cores used to limit memory usage.
- Reenable Python 3 builds
